### PR TITLE
Add graph visualization UI

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -5,50 +5,101 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>See Also</title>
     <script src="https://cdn.tailwindcss.com"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@600&family=Roboto&display=swap" rel="stylesheet">
+    <style>
+        body { font-family: 'Roboto', sans-serif; }
+        h1, h2 { font-family: 'Poppins', sans-serif; }
+        :root {
+            --primary: #6366f1;
+            --secondary: #0ea5e9;
+            --accent: #f43f5e;
+            --bg: #f0f4f8;
+        }
+        #tooltip { pointer-events: none; }
+    </style>
+    <script src="https://d3js.org/d3.v7.min.js"></script>
 </head>
-<body class="bg-gray-100 min-h-screen flex flex-col">
-    <div class="container mx-auto max-w-2xl py-12 px-4 flex-grow">
-        <h1 class="text-4xl font-extrabold text-center text-indigo-600 mb-8">Explore Related Concepts</h1>
-        <form method="post" class="space-y-4 mb-8">
-            <div>
-                <label for="text" class="block text-lg font-medium text-gray-700">Enter a concept or description</label>
-                <textarea id="text" name="text" rows="4" required class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">{{ user_text }}</textarea>
-            </div>
-            <button type="submit" class="w-full py-2 px-4 bg-indigo-600 text-white font-semibold rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">Generate</button>
+<body class="bg-[var(--bg)] min-h-screen">
+    <div class="p-4">
+        <form method="post" class="flex items-start space-x-2">
+            <textarea id="text" name="text" rows="2" placeholder="Enter a concept" required class="p-2 border rounded w-1/3">{{ user_text }}</textarea>
+            <button type="submit" class="px-4 py-2 bg-[var(--primary)] text-white rounded hover:bg-indigo-700">Generate</button>
         </form>
-        {% if concepts %}
-        <h2 class="text-2xl font-semibold mb-4">Related Concepts</h2>
-        <div class="space-y-4">
-            {% for c in concepts %}
-            <div class="bg-white shadow rounded-lg">
-                <button type="button" class="w-full px-4 py-3 flex justify-between items-center focus:outline-none" data-target="panel{{ loop.index }}">
-                    <span class="font-medium text-indigo-600">{{ c.short_name }}</span>
-                    <svg class="w-5 h-5 text-gray-500 transition-transform" data-icon="arrow" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
-                </button>
-                <div id="panel{{ loop.index }}" class="px-4 py-3 hidden border-t">
-                    <p class="mb-2"><span class="font-semibold">Definition:</span> {{ c.definition }}</p>
-                    <p class="mb-2">{{ c.explanation }}</p>
-                    <p><span class="font-semibold">Start here:</span> {{ c.start_here }}</p>
-                </div>
-            </div>
-            {% endfor %}
-        </div>
-        {% endif %}
     </div>
+    <div id="graph" class="relative w-full h-[600px]"></div>
+    <div id="tooltip" class="absolute bg-white border rounded shadow-lg p-4 hidden"></div>
+
+    {% if concepts %}
     <script>
-        document.querySelectorAll('button[data-target]').forEach(btn => {
-            btn.addEventListener('click', () => {
-                const panel = document.getElementById(btn.getAttribute('data-target'));
-                const icon = btn.querySelector('[data-icon="arrow"]');
-                if (panel.classList.contains('hidden')) {
-                    panel.classList.remove('hidden');
-                    icon.classList.add('transform', 'rotate-180');
-                } else {
-                    panel.classList.add('hidden');
-                    icon.classList.remove('transform', 'rotate-180');
-                }
-            });
+        const data = {{ concepts | tojson | safe }};
+        const rootText = {{ user_text | tojson | safe }};
+        const width = document.getElementById('graph').clientWidth;
+        const height = document.getElementById('graph').clientHeight;
+        const nodes = [{id: 'root', label: rootText, fx: width/2, fy: height/2}];
+        const links = [];
+        data.forEach((c, i) => {
+            nodes.push({id: i, label: c.short_name, info: c});
+            links.push({source: 'root', target: i});
         });
+        const svg = d3.select('#graph').append('svg')
+            .attr('width', width)
+            .attr('height', height);
+        const simulation = d3.forceSimulation(nodes)
+            .force('link', d3.forceLink(links).id(d => d.id).distance(120))
+            .force('charge', d3.forceManyBody().strength(-300))
+            .force('center', d3.forceCenter(width/2, height/2));
+
+        const link = svg.append('g')
+            .selectAll('line')
+            .data(links)
+            .enter().append('line')
+            .attr('stroke', '#ccc');
+
+        const node = svg.append('g')
+            .selectAll('g')
+            .data(nodes)
+            .enter().append('g')
+            .call(d3.drag()
+                .on('start', dragstarted)
+                .on('drag', dragged)
+                .on('end', dragended));
+
+        node.append('circle')
+            .attr('r', 20)
+            .attr('fill', (d,i) => i === 0 ? 'var(--primary)' : 'var(--secondary)')
+            .on('mousemove', showTooltip)
+            .on('mouseout', hideTooltip);
+
+        node.append('text')
+            .text(d => d.label)
+            .attr('text-anchor', 'middle')
+            .attr('dy', '.35em')
+            .attr('class', 'text-xs pointer-events-none');
+
+        simulation.on('tick', () => {
+            link.attr('x1', d => d.source.x)
+                .attr('y1', d => d.source.y)
+                .attr('x2', d => d.target.x)
+                .attr('y2', d => d.target.y);
+            node.attr('transform', d => `translate(${d.x},${d.y})`);
+        });
+
+        const tooltip = document.getElementById('tooltip');
+        function showTooltip(event, d) {
+            if(!d.info) return;
+            tooltip.innerHTML = `<h2 class='font-bold mb-1'>${d.label}</h2>` +
+                `<p class='text-sm mb-1'><strong>Definition:</strong> ${d.info.definition}</p>` +
+                `<p class='text-sm mb-1'>${d.info.explanation}</p>` +
+                `<p class='text-sm'><strong>Start here:</strong> ${d.info.start_here}</p>`;
+            tooltip.style.left = (event.pageX + 10) + 'px';
+            tooltip.style.top = (event.pageY + 10) + 'px';
+            tooltip.classList.remove('hidden');
+        }
+        function hideTooltip() { tooltip.classList.add('hidden'); }
+        function dragstarted(event) { if (!event.active) simulation.alphaTarget(0.3).restart(); event.subject.fx = event.subject.x; event.subject.fy = event.subject.y; }
+        function dragged(event) { event.subject.fx = event.x; event.subject.fy = event.y; }
+        function dragended(event) { if (!event.active) simulation.alphaTarget(0); event.subject.fx = null; event.subject.fy = null; }
     </script>
+    {% endif %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- revamp HTML template with new fonts and color palette
- allow user to input text in the top-left form
- visualise related concepts in a D3 force-directed graph
- show concept details on hover

## Testing
- `python -m py_compile app.py gpt.py`


------
https://chatgpt.com/codex/tasks/task_b_685681168530832482265151db625e3e