### PR TITLE
Enhance web UI with dark mode and graph reset

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -15,6 +15,13 @@
             --accent: #f43f5e;
             --bg: #f0f4f8;
         }
+        body.dark {
+            --primary: #818cf8;
+            --secondary: #38bdf8;
+            --accent: #f87171;
+            --bg: #1f2937;
+            color: #f9fafb;
+        }
         #tooltip { pointer-events: none; }
         #notification { transition: opacity 0.3s; }
         @keyframes pulse {
@@ -39,10 +46,16 @@
 </head>
 <body class="bg-[var(--bg)] min-h-screen">
     <div class="p-4">
-        <form method="post" class="flex items-start space-x-2">
-            <textarea id="text" name="text" rows="2" placeholder="Enter a concept" required class="p-2 border rounded w-1/3">{{ user_text }}</textarea>
-            <button type="submit" class="px-4 py-2 bg-[var(--primary)] text-white rounded hover:bg-indigo-700">Generate</button>
-        </form>
+        <div class="flex items-start justify-between space-x-4">
+            <form method="post" class="flex items-start space-x-2">
+                <textarea id="text" name="text" rows="2" placeholder="Enter a concept" required class="p-2 border rounded w-1/3">{{ user_text }}</textarea>
+                <button type="submit" class="px-4 py-2 bg-[var(--primary)] text-white rounded hover:bg-indigo-700">Generate</button>
+            </form>
+            <div class="flex items-center space-x-2">
+                <button id="clearGraph" type="button" class="px-3 py-2 bg-[var(--secondary)] text-white rounded hover:bg-sky-700 hidden">Clear</button>
+                <button id="toggleTheme" type="button" class="px-3 py-2 border rounded">Dark mode</button>
+            </div>
+        </div>
     </div>
     <div id="graph" class="relative w-full h-[600px]"></div>
     <div id="tooltip" class="absolute bg-white border rounded shadow-lg p-4 hidden"></div>
@@ -50,16 +63,37 @@
 
     <script>
         const notifyEl = document.getElementById('notification');
+        const textEl = document.getElementById('text');
+        const themeBtn = document.getElementById('toggleTheme');
+        const clearBtn = document.getElementById('clearGraph');
+
+        const spinner = `<svg class="animate-spin h-4 w-4 mr-2 inline-block text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path></svg>`;
+
         function showNotification(msg, error=false) {
-            notifyEl.textContent = msg;
+            notifyEl.innerHTML = msg;
             notifyEl.style.backgroundColor = error ? 'var(--accent)' : 'var(--primary)';
             notifyEl.classList.remove('hidden');
         }
+        function showLoading(msg='Generating concepts...') {
+            showNotification(spinner + msg);
+        }
         function hideNotification() { notifyEl.classList.add('hidden'); }
+
+        if (localStorage.getItem('theme') === 'dark') {
+            document.body.classList.add('dark');
+        }
+        themeBtn.addEventListener('click', () => {
+            document.body.classList.toggle('dark');
+            localStorage.setItem('theme', document.body.classList.contains('dark') ? 'dark' : 'light');
+        });
+
+        const savedText = localStorage.getItem('lastText');
+        if (!textEl.value && savedText) textEl.value = savedText;
 
         const formEl = document.querySelector('form');
         formEl.addEventListener('submit', () => {
-            showNotification('Generating concepts...');
+            showLoading();
+            localStorage.setItem('lastText', textEl.value);
         });
     </script>
 
@@ -165,6 +199,15 @@
             simulation.alpha(1).restart();
         }
 
+        function resetGraph() {
+            nodes.splice(1);
+            links.length = 0;
+            update();
+        }
+
+        clearBtn.addEventListener('click', resetGraph);
+        clearBtn.classList.remove('hidden');
+
         update();
         window.addEventListener('resize', resize);
 
@@ -204,7 +247,7 @@
             event.stopPropagation();
             const circle = d3.select(event.target.parentNode).select('circle');
             circle.classed('pulsing', true);
-            showNotification('Generating concepts...');
+            showLoading();
             try {
                 const res = await fetch('/expand', {
                     method: 'POST',


### PR DESCRIPTION
## Summary
- add dark theme variables
- provide graph reset and theme toggle buttons
- persist theme and last entered text in localStorage
- show spinner notification when generating concepts

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_685689f6a1c88324836c69d7f94404ae