### PR TITLE
Improve palette controls

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -50,18 +50,18 @@
 <body class="bg-[var(--bg)] min-h-screen">
     <div class="p-4">
         <div class="flex items-start justify-between space-x-4">
-            <form method="post" class="flex items-start space-x-2">
-                <textarea id="text" name="text" rows="2" placeholder="Enter a concept" required class="p-2 border rounded w-1/3">{{ user_text }}</textarea>
+            <form method="post" class="flex items-start flex-1 space-x-2">
+                <textarea id="text" name="text" rows="2" placeholder="Enter a concept" required class="p-2 border rounded w-full flex-grow">{{ user_text }}</textarea>
                 <button type="submit" class="px-4 py-2 bg-[var(--primary)] text-white rounded hover:bg-indigo-700">Generate</button>
             </form>
             <div class="flex items-center space-x-2">
-                <select id="paletteSelect" class="p-2 border rounded">
-                    <option value="category10">Default</option>
-                    <option value="monochromatic">Monochromatic</option>
-                    <option value="analogous">Analogous</option>
-                    <option value="complementary">Complementary</option>
-                    <option value="triadic">Triadic</option>
-                </select>
+                <div id="paletteDropdown" class="relative">
+                    <button id="paletteButton" type="button" class="p-2 border rounded flex items-center space-x-1">
+                        <div id="palettePreview" class="flex space-x-1"></div>
+                        <svg class="w-4 h-4" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 10.94l3.71-3.71a.75.75 0 111.08 1.04l-4.25 4.25a.75.75 0 01-1.08 0L5.25 8.27a.75.75 0 01-.02-1.06z" clip-rule="evenodd"/></svg>
+                    </button>
+                    <div id="paletteMenu" class="absolute right-0 mt-2 border rounded bg-white shadow-lg hidden z-10"></div>
+                </div>
                 <button id="clearGraph" type="button" class="px-3 py-2 bg-[var(--secondary)] text-white rounded hover:bg-sky-700 hidden">Clear</button>
                 <button id="toggleTheme" type="button" class="px-3 py-2 border rounded">
                     <svg id="themeIcon" xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor"></svg>
@@ -79,7 +79,10 @@
         const themeBtn = document.getElementById('toggleTheme');
         const themeIcon = document.getElementById('themeIcon');
         const clearBtn = document.getElementById('clearGraph');
-        const paletteSelect = document.getElementById('paletteSelect');
+        const paletteBtn = document.getElementById('paletteButton');
+        const paletteMenu = document.getElementById('paletteMenu');
+        const palettePreview = document.getElementById('palettePreview');
+        const paletteDropdown = document.getElementById('paletteDropdown');
 
         const palettes = {
             category10: d3.schemeCategory10,
@@ -115,14 +118,45 @@
         updateThemeIcon();
 
         let paletteName = localStorage.getItem('palette') || 'category10';
-        paletteSelect.value = paletteName;
+        window.colorPalette = palettes[paletteName];
+        document.documentElement.style.setProperty('--primary', window.colorPalette[0]);
 
-        paletteSelect.addEventListener('change', () => {
-            paletteName = paletteSelect.value;
-            localStorage.setItem('palette', paletteName);
-            window.colorPalette = palettes[paletteName];
-            document.documentElement.style.setProperty('--primary', window.colorPalette[0]);
-            if (window.applyPalette) window.applyPalette();
+        function renderPreview(target, colors) {
+            target.innerHTML = colors.slice(0, 4).map(c => `<span class="w-4 h-4 rounded" style="background-color:${c}"></span>`).join('');
+        }
+
+        function buildPaletteMenu() {
+            for (const [name, colors] of Object.entries(palettes)) {
+                const opt = document.createElement('div');
+                opt.className = 'px-2 py-1 flex items-center space-x-2 hover:bg-gray-100 cursor-pointer';
+                opt.dataset.value = name;
+                const label = name === 'category10' ? 'Default' : name;
+                opt.innerHTML = `<div class="flex space-x-1">${colors.slice(0,4).map(c => `<span class=\"w-4 h-4 rounded\" style=\"background-color:${c}\"></span>`).join('')}</div><span>${label}</span>`;
+                opt.addEventListener('click', () => {
+                    paletteName = name;
+                    localStorage.setItem('palette', paletteName);
+                    window.colorPalette = palettes[paletteName];
+                    document.documentElement.style.setProperty('--primary', window.colorPalette[0]);
+                    renderPreview(palettePreview, window.colorPalette);
+                    if (window.applyPalette) window.applyPalette();
+                    paletteMenu.classList.add('hidden');
+                });
+                paletteMenu.appendChild(opt);
+            }
+        }
+
+        buildPaletteMenu();
+        renderPreview(palettePreview, palettes[paletteName]);
+
+        paletteBtn.addEventListener('click', e => {
+            e.stopPropagation();
+            paletteMenu.classList.toggle('hidden');
+        });
+
+        document.addEventListener('click', e => {
+            if (!paletteDropdown.contains(e.target)) {
+                paletteMenu.classList.add('hidden');
+            }
         });
 
         themeBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- revamp colour palette selection with a preview menu
- keep palette changes applied to all nodes
- widen the concept entry area

## Testing
- `python -m py_compile app.py gpt.py`


------
https://chatgpt.com/codex/tasks/task_b_6856941faa348324949d6a39846b9eee