### PR TITLE
Add definitions toggle

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -66,6 +66,7 @@
                     <div id="paletteMenu" class="absolute right-0 mt-2 border rounded bg-white shadow-lg hidden z-10"></div>
                 </div>
                 <button id="clearGraph" type="button" class="px-3 py-2 bg-[var(--secondary)] text-white rounded hover:bg-sky-700 hidden">Clear</button>
+                <button id="toggleDefs" type="button" class="px-3 py-2 border rounded">Show Definitions</button>
                 <button id="toggleTheme" type="button" class="px-3 py-2 border rounded">
                     <svg id="themeIcon" xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor"></svg>
                 </button>
@@ -82,12 +83,15 @@
         const themeBtn = document.getElementById('toggleTheme');
         const themeIcon = document.getElementById('themeIcon');
         const clearBtn = document.getElementById('clearGraph');
+        const defsBtn = document.getElementById('toggleDefs');
         const paletteBtn = document.getElementById('paletteButton');
         const paletteMenu = document.getElementById('paletteMenu');
         const palettePreview = document.getElementById('palettePreview');
         const paletteDropdown = document.getElementById('paletteDropdown');
         const inputWrapper = document.getElementById('inputWrapper');
         const showInputBtn = document.getElementById('showInput');
+
+        let showDefinitions = false;
 
         const palettes = {
             category10: d3.schemeCategory10,
@@ -177,6 +181,12 @@
 
         showInputBtn.addEventListener('click', expandInput);
 
+        defsBtn.addEventListener('click', () => {
+            showDefinitions = !showDefinitions;
+            defsBtn.textContent = showDefinitions ? 'Hide Definitions' : 'Show Definitions';
+            if (window.updateNodes) window.updateNodes();
+        });
+
         themeBtn.addEventListener('click', () => {
             const dark = document.body.classList.toggle('dark');
             localStorage.setItem('theme', dark ? 'dark' : 'light');
@@ -247,6 +257,14 @@
             return baseRadius * Math.max(0.5, 1 - depth * 0.15);
         }
 
+        function linkSourceId(l) {
+            return typeof l.source === 'object' ? l.source.id : l.source;
+        }
+
+        function linkTargetId(l) {
+            return typeof l.target === 'object' ? l.target.id : l.target;
+        }
+
         function applyPalette() {
             colorIndex = 0;
             nodes.forEach(n => {
@@ -258,9 +276,9 @@
             });
             nodes.forEach(n => {
                 if (n.depth > 1) {
-                    const parentLink = links.find(l => l.target === n.id);
+                    const parentLink = links.find(l => linkTargetId(l) === n.id);
                     if (parentLink) {
-                        const parentNode = nodes.find(x => x.id === parentLink.source);
+                        const parentNode = nodes.find(x => x.id === linkSourceId(parentLink));
                         if (parentNode) n.color = parentNode.color;
                     }
                 }
@@ -270,6 +288,28 @@
         window.applyPalette = applyPalette;
 
         // idCounter already tracks the next numeric id for new nodes
+
+        function wrapText(text, width) {
+            text.each(function () {
+                const textEl = d3.select(this);
+                const words = textEl.text().split(/\s+/).reverse();
+                let word, line = [], lineNumber = 0;
+                const lineHeight = 1.1; // ems
+                const y = textEl.attr('y');
+                const dy = parseFloat(textEl.attr('dy')) || 0;
+                let tspan = textEl.text(null).append('tspan').attr('x', 0).attr('y', y).attr('dy', dy + 'em');
+                while (word = words.pop()) {
+                    line.push(word);
+                    tspan.text(line.join(' '));
+                    if (tspan.node().getComputedTextLength() > width && line.length > 1) {
+                        line.pop();
+                        tspan.text(line.join(' '));
+                        line = [word];
+                        tspan = textEl.append('tspan').attr('x', 0).attr('y', y).attr('dy', ++lineNumber * lineHeight + dy + 'em').text(word);
+                    }
+                }
+            });
+        }
 
         function update() {
             link = link.data(links);
@@ -305,14 +345,25 @@
                 .attr('dy', d => (d.id === 'root' ? baseRadius*1.3 : radiusByDepth(d.depth || 1)) + 12)
                 .attr('class', 'text-xs pointer-events-none');
 
+            nodeEnter.append('text')
+                .attr('class', 'definition text-[10px] pointer-events-none')
+                .attr('text-anchor', 'middle')
+                .attr('dy', d => (d.id === 'root' ? baseRadius*1.3 : radiusByDepth(d.depth || 1)) + 24);
+
             node = nodeEnter.merge(node);
             node.select('circle')
                 .attr('fill', d => d.id === 'root' ? 'var(--primary)' : (d.color || 'var(--secondary)'));
+
+            node.select('text.definition')
+                .text(d => showDefinitions && d.info ? d.info.definition : '')
+                .each(function(d){ if(showDefinitions && d.info){ wrapText(d3.select(this), 120); } else { d3.select(this).selectAll('tspan').remove(); }});
 
             simulation.nodes(nodes);
             simulation.force('link').links(links);
             simulation.alpha(1).restart();
         }
+
+        window.updateNodes = update;
 
         function resize() {
             width = graphDiv.clientWidth;


### PR DESCRIPTION
## Summary
- add `toggleDefs` button to optionally show definitions
- insert `wrapText` helper for definition text wrapping
- display definitions when toggled via new button
- propagate palette colors throughout all levels

## Testing
- `python -m py_compile app.py gpt.py`


------
https://chatgpt.com/codex/tasks/task_b_6856976ffdc08324b1912236d22d5f7a