### PR TITLE
Improve definition visibility and hide input option

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -44,6 +44,13 @@
             transform-box: fill-box;
             transform-origin: center;
         }
+        .definition {
+            opacity: 0.8;
+            font-style: italic;
+        }
+        .label {
+            font-weight: 600;
+        }
     </style>
     <script src="https://d3js.org/d3.v7.min.js"></script>
 </head>
@@ -55,6 +62,7 @@
                     <textarea id="text" name="text" rows="2" placeholder="Enter a concept" required class="p-2 border rounded flex-grow">{{ user_text }}</textarea>
                     <button type="submit" class="px-4 py-2 bg-[var(--primary)] text-white rounded hover:bg-indigo-700">Generate</button>
                 </form>
+                <button id="hideInput" type="button" class="text-xs text-gray-500 underline self-center">Hide</button>
             </div>
             <button id="showInput" type="button" class="px-3 py-2 border rounded hidden mr-2">Show Input</button>
             <div class="flex items-center space-x-2">
@@ -90,6 +98,7 @@
         const paletteDropdown = document.getElementById('paletteDropdown');
         const inputWrapper = document.getElementById('inputWrapper');
         const showInputBtn = document.getElementById('showInput');
+        const hideInputBtn = document.getElementById('hideInput');
 
         let showDefinitions = localStorage.getItem('showDefinitions') === 'true';
         defsBtn.textContent = showDefinitions ? 'Hide Definitions' : 'Show Definitions';
@@ -175,15 +184,18 @@
         function collapseInput() {
             inputWrapper.classList.add('hidden');
             showInputBtn.classList.remove('hidden');
+            hideInputBtn.classList.add('hidden');
         }
 
         function expandInput() {
             inputWrapper.classList.remove('hidden');
             showInputBtn.classList.add('hidden');
+            hideInputBtn.classList.remove('hidden');
             textEl.focus();
         }
 
         showInputBtn.addEventListener('click', expandInput);
+        hideInputBtn.addEventListener('click', collapseInput);
 
         defsBtn.addEventListener('click', () => {
             showDefinitions = !showDefinitions;
@@ -347,10 +359,10 @@
                 .text(d => d.label)
                 .attr('text-anchor', 'middle')
                 .attr('dy', d => (d.id === 'root' ? baseRadius*1.3 : radiusByDepth(d.depth || 1)) + 12)
-                .attr('class', 'text-xs pointer-events-none');
+                .attr('class', 'label text-xs font-semibold pointer-events-none');
 
             nodeEnter.append('text')
-                .attr('class', 'definition text-[10px] pointer-events-none')
+                .attr('class', 'definition text-[10px] pointer-events-none opacity-80 italic')
                 .attr('text-anchor', 'middle')
                 .attr('y', d => (d.id === 'root' ? baseRadius*1.3 : radiusByDepth(d.depth || 1)) + 24);
 


### PR DESCRIPTION
## Summary
- highlight graph labels and dim definition text for clarity
- let users hide or show the input controls

## Testing
- `python -m py_compile app.py gpt.py`


------
https://chatgpt.com/codex/tasks/task_b_68569c4461a883249cd3e589e7a30ae4